### PR TITLE
Add docstrings and rename variable

### DIFF
--- a/Scripts/TransformerKql.py
+++ b/Scripts/TransformerKql.py
@@ -4,19 +4,16 @@ import re
 import os
 import sys
 def sanitize_filename(filename):
-    """
-    Sanitize the filename to remove any characters that might not be valid in file names.
-    """
-    return re.sub(r'[\\/*?:"<>|]', "", filename)  # Remove characters not allowed in filenames
+    """Return a filename stripped of characters invalid on most filesystems."""
+    return re.sub(r'[\\/*?:"<>|]', "", filename)
 def ensure_directory_exists(directory):
-    """
-    Ensure that a directory exists; if not, create it.
-    """
+    """Create directory if it is missing."""
     if not os.path.exists(directory):
         os.makedirs(directory)
 def generate_kql_query(data, detection_output_directory, generic_output_directory):
+    """Create KQL queries based on HijackLibs API data."""
     initial_transforms = "DeviceImageLoadEvents\n| extend FileName = tolower(FileName), FolderPath = tolower(FolderPath), InitiatingProcessFileName = tolower(InitiatingProcessFileName)\n"
-    FileProfile = "\n| invoke FileProfile(\"SHA1\", 1000)\n"
+    file_profile = "\n| invoke FileProfile(\"SHA1\", 1000)\n"
     all_conditions = []
     for entry in data:
         individual_conditions = []
@@ -56,12 +53,12 @@ def generate_kql_query(data, detection_output_directory, generic_output_director
         # Writing individual file
         safe_dll_name = sanitize_filename(dll_name)
         with open(f"{detection_output_directory}/{safe_dll_name}_detection_query.kql", "w") as file:
-            individual_query = initial_transforms + "| where " + " and ".join(individual_conditions) + FileProfile
+            individual_query = initial_transforms + "| where " + " and ".join(individual_conditions) + file_profile
             file.write(individual_query)
     # Constructing the combined query
     combined_conditions = " or ".join(all_conditions)
     combined_conditions = combined_conditions.replace(" or (FileName", "\nor (FileName")
-    combined_query = initial_transforms + "| where " + combined_conditions + FileProfile
+    combined_query = initial_transforms + "| where " + combined_conditions + file_profile
     # Writing the combined query to a file
     ensure_directory_exists(generic_output_directory)
     with open(f"{generic_output_directory}/all_detection_queries.kql", "w") as combined_file:


### PR DESCRIPTION
## Summary
- add concise docstrings for helper functions
- rename `FileProfile` variable to `file_profile`
- adjust query generation for new variable name

## Testing
- `python -m py_compile Scripts/TransformerKql.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c3a905348330bc20016c27716bd9